### PR TITLE
docs(readme): clarify Vitess/MySQL vs Postgres

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learn how to integrate PlanetScale with a sample Django application
 
-> **Note:** This tutorial targets PlanetScale Vitess/MySQL (including the MySQL-focused Django connection flow below). PlanetScale also offers managed PostgreSQL; use Django's PostgreSQL database backend and Postgres connection settings for those databases. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This tutorial targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This sample application demonstrates how to connect to a PlanetScale MySQL database, create and run migrations, seed the database, and display the data.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Learn how to integrate PlanetScale with a sample Django application
 
+> **Note:** This tutorial targets PlanetScale Vitess/MySQL (including the MySQL-focused Django connection flow below). PlanetScale also offers managed PostgreSQL; use Django's PostgreSQL database backend and Postgres connection settings for those databases. For more information and examples, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+
 This sample application demonstrates how to connect to a PlanetScale MySQL database, create and run migrations, seed the database, and display the data.
 
 For the full tutorial, see the [Django PlanetScale documentation](https://planetscale.com/docs/tutorials/connect-django-app).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Learn how to integrate PlanetScale with a sample Django application
 
-> **Note:** This tutorial targets PlanetScale Vitess/MySQL. PlanetScale also offers managed PostgreSQL. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
+> **Note:** This tutorial targets PlanetScale Vitess/MySQL. PlanetScale also offers managed Postgres. For more information, see the [PlanetScale Postgres documentation](https://planetscale.com/docs/postgres).
 
 This sample application demonstrates how to connect to a PlanetScale MySQL database, create and run migrations, seed the database, and display the data.
 


### PR DESCRIPTION
## Summary

- README: clarify that this repository targets PlanetScale Vitess/MySQL (or the MySQL tooling shown in the repo), not PlanetScale-only-MySQL.
- Link readers to Postgres documentation at https://planetscale.com/docs/postgres for managed PostgreSQL databases.

PlanetScale offers both MySQL-compatible (Vitess) and PostgreSQL products.

Made with [Cursor](https://cursor.com)